### PR TITLE
Include metadata in image manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 git-metadata-buildpack*
 git-metadata-buildpack*/
-coverage.out
+coverage.txt
 bin/
+vendor/
 
 .idea/


### PR DESCRIPTION
Using the HelperLayer overwrites the layer metadata with data that we cannot control. Instead, if we access the context layer instead then the BuildPlan will not get overwritten and we can pass in arbitrary metadata (so long as it implements the `Identity` method) that will then be automatically added to the image manifest.

See this Tracker [story](https://www.pivotaltracker.com/story/show/166611203) for more details.

We also updated the `.gitignore` to prevent tracking of auto-generated unit test coverage files as well as the `vendor` directory 